### PR TITLE
[deprecated] Update deprecated comlinkjs

### DIFF
--- a/src/fetch.worker.js
+++ b/src/fetch.worker.js
@@ -1,4 +1,4 @@
-importScripts('https://cdn.jsdelivr.net/npm/comlinkjs@2.3/comlink.global.min.js');
+importScripts('https://unpkg.com/comlink/dist/umd/comlink.js');
 
 class Fetch {
     constructor() {


### PR DESCRIPTION
## Description
`comlinkjs` in https://github.com/jadjoubran/comlink-fetch/blob/21006115453793a781114fba7b0543097eaba913/src/fetch.worker.js#L1 is deprecated, change to comlink instead. As for cdn link, there's an official link in [documentation](https://www.npmjs.com/package/comlink).